### PR TITLE
Create radarr-quality-profile-sqp-3-audio.yml and radarr-custom-formats-sqp-3-audio.yml

### DIFF
--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3-audio.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3-audio.yml
@@ -1,0 +1,96 @@
+custom_formats:
+  - trash_ids:
+      # Audio
+      - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
+      - 2f22d89048b01681dde8afe203bf2e95 # DTS X
+      - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
+      - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
+      - 3cafb66171b47f226146a0770576870f # TrueHD
+      - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
+      - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
+      - e7c2fcae07cbada050a0af3357491d7b # PCM
+      - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
+      - 185f1dd7264c4562b9022d963ac37424 # DD+
+      - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
+      - 1c1a4c5e823891c75bc50380a6866f73 # DTS
+      - 240770601cc226190c367ef59aba7463 # AAC
+      - c2998bd0d90ed5621d8df281e839436e # DD
+
+      # HDR Formats
+      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
+      - e23edd2482476e595fb990b12e7c609c # DV HDR10
+      - 58d6a88f13e2db7f5059c41047876f00 # DV
+      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
+      - a3e19f8f627608af0211acd02bf89735 # DV SDR
+      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
+      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
+      - e61e28db95d22bedcadf030b8f156d96 # HDR
+      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
+      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
+      - 9364dd386c9b4a1100dde8264690add7 # HLG
+
+      # Movie Versions
+      - 0f12c086e289cf966fa5948eac571f44 # Hybrid
+      - 570bc9ebecd92723d2d21500f4be314c # Remaster
+      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+      - 957d0f44b592285f26449575e8b1167e # Special Edition
+      - eecf3a857724171f968a66cb5719e152 # IMAX
+      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+
+      # HQ Release Groups
+      - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
+      - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
+      - 8baaf0b3142bf4d94c42a724f034e27a # Remux Tier 03
+      - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
+      - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
+      - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+
+      # Misc
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
+      - ae43b294509409a6a13919dedd4764c4 # Repack2
+      - 5caaaa1c08c1742aa4342d8c4cc463f2 # Repack3
+      - 2899d84dc9372de3408e6d8cc18e9666 # x264
+
+      # Unwanted
+      - ed38b889b31be83fda192888e2286d83 # BR-DISK
+      - 90a6f9a284dff5103f6346090e6280c8 # LQ
+      - e204b80c87be9497a8a6eaff48f72905 # LQ (Release Title)
+      - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+      - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+      - cae4ca30163749b891686f95532519bd # AV1
+
+      # Optional
+      - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+
+      # Resolution
+      - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
+      - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
+
+      # Streaming Services
+      - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
+      - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
+      - 2a6039655313bf5dab1e43523b62c374 # MA
+    assign_scores_to:
+      - name: SQP-3 (Audio)
+
+  - trash_ids:
+      # Streaming Services
+      - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
+      - 40e9380490e748672c2522eaaeb692f7 # ATVP
+      - 84272245b2988854bfb76a16e60baea5 # DSNP
+      - 509e5f41146e278f9eab1ddaceb34515 # HBO
+      - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
+      - 526d445d4c16214309f0fd2b3be18a89 # Hulu
+      - e0ec9672be6cac914ffad34a6b077209 # iT
+      - 6a061313d22e51e0f25b7cd4dc065233 # MAX
+      - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
+      - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
+      - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
+      - c2863d2a50c9acad1fb50e53ece60817 # STAN
+    assign_scores_to:
+      - name: SQP-3 (Audio)
+        score: 0


### PR DESCRIPTION
- added the new sqp-3 audio variant TRaSH released on 3/3/2024
- added new custom formats yml to go alongside new quality profile. Duplicate of sqp-3's custom format, but assigns to the new profile name.